### PR TITLE
V8PointerValue should not be GCed automatically. Fixes #2

### DIFF
--- a/v8runtime/V8PointerValue.cpp
+++ b/v8runtime/V8PointerValue.cpp
@@ -6,7 +6,6 @@ V8PointerValue::V8PointerValue(
     v8::Isolate *isolate,
     const v8::Local<v8::Value> &value)
     : value_(isolate, value) {
-  value_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
 }
 
 V8PointerValue::~V8PointerValue() {
@@ -16,14 +15,6 @@ V8PointerValue::~V8PointerValue() {
 v8::Local<v8::Value> V8PointerValue::Get(v8::Isolate *isolate) const {
   v8::EscapableHandleScope scopedIsolate(isolate);
   return scopedIsolate.Escape(value_.Get(isolate));
-}
-
-// static
-void V8PointerValue::Finalizer(
-    const v8::WeakCallbackInfo<V8PointerValue> &data) {
-  auto *pThis = data.GetParameter();
-  pThis->value_.Reset();
-  delete pThis;
 }
 
 // static

--- a/v8runtime/V8PointerValue.h
+++ b/v8runtime/V8PointerValue.h
@@ -14,8 +14,6 @@ class V8PointerValue final : public V8Runtime::PointerValue {
   v8::Local<v8::Value> Get(v8::Isolate *isolate) const;
 
  public:
-  static void Finalizer(const v8::WeakCallbackInfo<V8PointerValue> &data);
-
   static V8PointerValue *
   createFromOneByte(v8::Isolate *isolate, const char *str, size_t length);
 


### PR DESCRIPTION
JSI uses PointerValue to allocate String, Object, ...etc,
and JSI controls life cycle itself from invalidate().
JSCRuntime did use JSValueUnprotect() to prevent these values being GCed.
For V8Runtime, we just need to keep they wrapped as v8::Glocal<> and not as weak.

For #2, the `NativeModules.DialogManagerAndroid` will first initialize correctly.
However, during the callback from Alert button clicked, If GC happened, some properties in `NativeModules.DialogManagerAndroid` may not exist and lead to exception. 