### PR TITLE
Fix assertion for multiple JS reference to a HostObject

### DIFF
--- a/src/v8runtime/HostProxy.cpp
+++ b/src/v8runtime/HostProxy.cpp
@@ -165,8 +165,9 @@ void HostObjectProxy::Enumerator(
 void HostObjectProxy::Finalizer(
     const v8::WeakCallbackInfo<HostObjectProxy> &data) {
   auto *pThis = data.GetParameter();
-  assert(pThis->hostObject_.use_count() == 1);
-  pThis->hostObject_.reset();
+  if (pThis->hostObject_.use_count() == 1) {
+    pThis->hostObject_.reset();
+  }
   pThis->weakHandle_.Reset();
   delete pThis;
 }


### PR DESCRIPTION
# Why

fix the broken assumption for reanimated's `SharedValue` which may share a HostObject between different JS object