### PR TITLE
Fix override issue of root packaging options

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -146,9 +146,7 @@ android {
   packagingOptions {
     // println "Native libs debug enabled: ${debugNativeLibraries}"
     doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
-    excludes = [
-      "META-INF",
-      "META-INF/**",
+    excludes += [
       "**/libc++_shared.so",
       "**/libfbjni.so",
       "**/libjsi.so",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -147,6 +147,8 @@ android {
     // println "Native libs debug enabled: ${debugNativeLibraries}"
     doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
     excludes = [
+      "META-INF",
+      "META-INF/**",
       "**/libc++_shared.so",
       "**/libfbjni.so",
       "**/libjsi.so",


### PR DESCRIPTION
react-native-v8 version: v1.1.0

I got the following build errors from task `:react-native-v8:mergeDebugAndroidTestJavaResource` ([Detox](https://github.com/wix/Detox) build):

```
* What went wrong:
Execution failed for task ':react-native-v8:mergeDebugAndroidTestJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 21 files found with path 'META-INF/MANIFEST.MF' from inputs:
     ......
```

Add `META-INF` in excludes of packagingOptions will fix this.
