### PR TITLE
Add a pick first rule.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -154,6 +154,7 @@ android {
       "**/libglog.so",
       "**/libreactnativejni.so",
     ]
+    pickFirst "**/libv8android.so"
   }
   configurations {
     extractHeaders


### PR DESCRIPTION
Adding a pick first rule so that even if CMake adds linked libraries to the project the build will not get affected. 