### PR TITLE
Fix crash for accessing V8::Global dangling pointer

### DIFF
--- a/src/v8runtime/V8PointerValue.cpp
+++ b/src/v8runtime/V8PointerValue.cpp
@@ -12,16 +12,14 @@ namespace rnv8 {
 V8PointerValue::V8PointerValue(
     v8::Isolate *isolate,
     const v8::Local<v8::Value> &value)
-    : value_(isolate, value) {}
+    : isolate_(isolate), value_(isolate, value) {}
 
 V8PointerValue::V8PointerValue(
     v8::Isolate *isolate,
     v8::Global<v8::Value> &&value)
-    : value_(std::move(value)) {}
+    : isolate_(isolate), value_(std::move(value)) {}
 
-V8PointerValue::~V8PointerValue() {
-  value_.Reset();
-}
+V8PointerValue::~V8PointerValue() {}
 
 v8::Local<v8::Value> V8PointerValue::Get(v8::Isolate *isolate) const {
   v8::EscapableHandleScope scopedHandle(isolate);
@@ -65,6 +63,11 @@ V8PointerValue *V8PointerValue::createFromUtf8(
 }
 
 void V8PointerValue::invalidate() {
+  {
+    v8::Locker locker(isolate_);
+    v8::Isolate::Scope scopedIsolate(isolate_);
+    value_.Reset();
+  }
   delete this;
 }
 

--- a/src/v8runtime/V8PointerValue.h
+++ b/src/v8runtime/V8PointerValue.h
@@ -20,7 +20,7 @@ class V8PointerValue final : public V8Runtime::PointerValue {
   // Passing Global value directly
   V8PointerValue(v8::Isolate *isolate, v8::Global<v8::Value> &&value);
 
-  ~V8PointerValue();
+  ~V8PointerValue() override;
 
   v8::Local<v8::Value> Get(v8::Isolate *isolate) const;
 
@@ -37,6 +37,7 @@ class V8PointerValue final : public V8Runtime::PointerValue {
  private:
   friend class JSIV8ValueConverter;
   friend class V8Runtime;
+  v8::Isolate *isolate_;
   v8::Global<v8::Value> value_;
 };
 


### PR DESCRIPTION
when `V8::Global::Reset` in V8PointerValue dtor, we should also protect by a lock. otherwise, there're chances to access dangling pointers.

that should fix the problem @jzxchiang1 had in https://github.com/software-mansion/react-native-reanimated/pull/3132#issuecomment-1112878884