### PR TITLE
Fix v8 profiler 

### DIFF
--- a/android/src/main/cpp/V8ExecutorFactory.cpp
+++ b/android/src/main/cpp/V8ExecutorFactory.cpp
@@ -22,9 +22,10 @@ namespace rnv8 {
 namespace {
 
 std::unique_ptr<jsi::Runtime> makeV8RuntimeSystraced(
-    std::unique_ptr<V8RuntimeConfig> config) {
+    std::unique_ptr<V8RuntimeConfig> config, 
+    std::shared_ptr<react::MessageQueueThread> jsQueue) {
   react::SystraceSection s("V8ExecutorFactory::makeV8RuntimeSystraced");
-  return createV8Runtime(std::move(config));
+  return createV8Runtime(std::move(config), jsQueue);
 }
 
 } // namespace
@@ -33,7 +34,7 @@ std::unique_ptr<react::JSExecutor> V8ExecutorFactory::createJSExecutor(
     std::shared_ptr<react::ExecutorDelegate> delegate,
     std::shared_ptr<react::MessageQueueThread> jsQueue) {
   std::unique_ptr<jsi::Runtime> v8Runtime =
-      makeV8RuntimeSystraced(std::move(config_));
+      makeV8RuntimeSystraced(std::move(config_), jsQueue);
 
   // Add js engine information to Error.prototype so in error reporting we
   // can send this information.

--- a/src/v8runtime/V8Inspector.cpp
+++ b/src/v8runtime/V8Inspector.cpp
@@ -250,6 +250,7 @@ void InspectorClient::DispatchProxy(const std::string &message) {
           reinterpret_cast<const uint8_t *>(normalizedString.data()),
           normalizedString.size());
 
+  // For `v8::CpuProfiler` or some other modules with thread local storage, we should dispatch messages in the js thread.
   if (method == "Profiler.start" || method == "Profiler.stop") {
     jsQueue_->runOnQueue([this, messageView]() {
         v8::Isolate *isolate = GetIsolate();

--- a/src/v8runtime/V8Inspector.cpp
+++ b/src/v8runtime/V8Inspector.cpp
@@ -138,7 +138,7 @@ InspectorClient::InspectorClient(
     v8::Local<v8::Context> context,
     const std::string &appName,
     const std::string &deviceName) {
-  this->jsQueue = jsQueue;    
+  jsQueue_ = jsQueue;    
   isolate_ = context->GetIsolate();
   v8::HandleScope scopedHandle(isolate_);
   channel_.reset(new InspectorFrontend(this, context));
@@ -251,7 +251,7 @@ void InspectorClient::DispatchProxy(const std::string &message) {
           normalizedString.size());
 
   if (method == "Profiler.start" || method == "Profiler.stop") {
-    jsQueue->runOnQueue([this, messageView]() {
+    jsQueue_->runOnQueue([this, messageView]() {
         v8::Isolate *isolate = GetIsolate();
         v8::Locker locker(isolate);
         v8::Isolate::Scope scopedIsolate(isolate);

--- a/src/v8runtime/V8Inspector.cpp
+++ b/src/v8runtime/V8Inspector.cpp
@@ -134,9 +134,11 @@ class LocalConnection : public react::ILocalConnection {
 int InspectorClient::nextContextGroupId_ = 1;
 
 InspectorClient::InspectorClient(
+    std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
     v8::Local<v8::Context> context,
     const std::string &appName,
     const std::string &deviceName) {
+  this->jsQueue = jsQueue;    
   isolate_ = context->GetIsolate();
   v8::HandleScope scopedHandle(isolate_);
   channel_.reset(new InspectorFrontend(this, context));
@@ -238,6 +240,31 @@ void InspectorClient::AwakePauseLockWithMessage(const std::string &message) {
   pauseWaitable_.notify_all();
 }
 
+void InspectorClient::DispatchProxy(const std::string &message) {
+  std::string normalizedString = stripMetroCachePrevention(message);
+
+  auto messageObj = folly::parseJson(message);
+  auto method = messageObj["method"].asString();
+
+  v8_inspector::StringView messageView(
+          reinterpret_cast<const uint8_t *>(normalizedString.data()),
+          normalizedString.size());
+
+  if (method == "Profiler.start" || method == "Profiler.stop") {
+    jsQueue->runOnQueue([this, messageView]() {
+        v8::Isolate *isolate = GetIsolate();
+        v8::Locker locker(isolate);
+        v8::Isolate::Scope scopedIsolate(isolate);
+        v8::HandleScope scopedHandle(isolate);
+        v8::Context::Scope scopedContext(GetContext().Get(isolate));
+        session_->dispatchProtocolMessage(messageView);
+    });
+    return;
+  }
+
+  session_->dispatchProtocolMessage(messageView);
+}
+
 void InspectorClient::DispatchProtocolMessage(const std::string &message) {
   auto session = GetInspectorSession();
   if (!session) {
@@ -248,11 +275,7 @@ void InspectorClient::DispatchProtocolMessage(const std::string &message) {
   v8::Isolate::Scope scopedIsolate(isolate);
   v8::HandleScope scopedHandle(isolate);
   v8::Context::Scope scopedContext(GetContext().Get(isolate));
-  std::string normalizedString = stripMetroCachePrevention(message);
-  v8_inspector::StringView messageView(
-      reinterpret_cast<const uint8_t *>(normalizedString.data()),
-      normalizedString.size());
-  session->dispatchProtocolMessage(messageView);
+  DispatchProxy(message);
 }
 
 void InspectorClient::DispatchProtocolMessages(
@@ -268,11 +291,7 @@ void InspectorClient::DispatchProtocolMessages(
   v8::Context::Scope scopedContext(GetContext().Get(isolate));
 
   for (auto &message : messages) {
-    std::string normalizedString = stripMetroCachePrevention(message);
-    v8_inspector::StringView messageView(
-        reinterpret_cast<const uint8_t *>(normalizedString.data()),
-        normalizedString.size());
-    session->dispatchProtocolMessage(messageView);
+    DispatchProxy(message);
   }
 }
 

--- a/src/v8runtime/V8Inspector.h
+++ b/src/v8runtime/V8Inspector.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <condition_variable>
-
+#include <cxxreact/MessageQueueThread.h>
 #include "jsinspector/InspectorInterfaces.h"
 #include "v8-inspector.h"
 
@@ -43,6 +43,7 @@ class InspectorClient final
       public std::enable_shared_from_this<InspectorClient> {
  public:
   InspectorClient(
+      std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
       v8::Local<v8::Context> context,
       const std::string &appName,
       const std::string &deviceName);
@@ -58,12 +59,14 @@ class InspectorClient final
   void SendRemoteMessage(const v8_inspector::StringView &message);
   bool IsPaused();
   void AwakePauseLockWithMessage(const std::string &message);
+  void DispatchProxy(const std::string &message);
   void DispatchProtocolMessage(const std::string &message);
   void DispatchProtocolMessages(const std::vector<std::string> &messages);
 
   v8::Isolate *GetIsolate();
   v8::Global<v8::Context> &GetContext();
   v8_inspector::V8InspectorSession *GetInspectorSession();
+  std::shared_ptr<facebook::react::MessageQueueThread> jsQueue;
 
  private:
   static std::string CreateInspectorName(

--- a/src/v8runtime/V8Inspector.h
+++ b/src/v8runtime/V8Inspector.h
@@ -66,7 +66,7 @@ class InspectorClient final
   v8::Isolate *GetIsolate();
   v8::Global<v8::Context> &GetContext();
   v8_inspector::V8InspectorSession *GetInspectorSession();
-  std::shared_ptr<facebook::react::MessageQueueThread> jsQueue;
+  std::shared_ptr<facebook::react::MessageQueueThread> jsQueue_;
 
  private:
   static std::string CreateInspectorName(

--- a/src/v8runtime/V8PointerValue.cpp
+++ b/src/v8runtime/V8PointerValue.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "V8PointerValue.h"
+#include <cxxreact/MessageQueueThread.h>
 
 namespace rnv8 {
 

--- a/src/v8runtime/V8PointerValue.cpp
+++ b/src/v8runtime/V8PointerValue.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "V8PointerValue.h"
-#include <cxxreact/MessageQueueThread.h>
 
 namespace rnv8 {
 

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<facebook::react::MessageQueueThread> jsQueue)
   jsQueue_ = jsQueue;
   if (config_->enableInspector) {
     inspectorClient_ = std::make_shared<InspectorClient>(
-        jsQueue, context_.Get(isolate_), config_->appName, config_->deviceName);
+        jsQueue_, context_.Get(isolate_), config_->appName, config_->deviceName);
     inspectorClient_->ConnectToReactFrontend();
   }
 }
@@ -83,7 +83,7 @@ V8Runtime::V8Runtime(
   // We don't need to register another idle taskrunner again
   isRegisteredIdleTaskRunner_ = true;
   isolate_ = v8Runtime->isolate_;
-  this->jsQueue = v8Runtime->jsQueue;
+  this->jsQueue_ = v8Runtime->jsQueue_;
 
   v8::Locker locker(isolate_);
   v8::Isolate::Scope scopedIsolate(isolate_);

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -83,7 +83,7 @@ V8Runtime::V8Runtime(
   // We don't need to register another idle taskrunner again
   isRegisteredIdleTaskRunner_ = true;
   isolate_ = v8Runtime->isolate_;
-  this->jsQueue_ = v8Runtime->jsQueue_;
+  jsQueue_ = v8Runtime->jsQueue_;
 
   v8::Locker locker(isolate_);
   v8::Isolate::Scope scopedIsolate(isolate_);

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -108,7 +108,7 @@ V8Runtime::V8Runtime(
 
   if (config_->enableInspector) {
     inspectorClient_ = std::make_shared<InspectorClient>(
-        this->jsQueue, context_.Get(isolate_), config_->appName, config_->deviceName);
+        this->jsQueue_, context_.Get(isolate_), config_->appName, config_->deviceName);
     inspectorClient_->ConnectToReactFrontend();
   }
 }

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -108,7 +108,7 @@ V8Runtime::V8Runtime(
 
   if (config_->enableInspector) {
     inspectorClient_ = std::make_shared<InspectorClient>(
-        this->jsQueue_, context_.Get(isolate_), config_->appName, config_->deviceName);
+        jsQueue_, context_.Get(isolate_), config_->appName, config_->deviceName);
     inspectorClient_->ConnectToReactFrontend();
   }
 }

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<facebook::react::MessageQueueThread> jsQueue)
   v8::HandleScope scopedHandle(isolate_);
   context_.Reset(isolate_, CreateGlobalContext(isolate_));
   v8::Context::Scope scopedContext(context_.Get(isolate_));
-  this->jsQueue = jsQueue;
+  jsQueue_ = jsQueue;
   if (config_->enableInspector) {
     inspectorClient_ = std::make_shared<InspectorClient>(
         jsQueue, context_.Get(isolate_), config_->appName, config_->deviceName);

--- a/src/v8runtime/V8Runtime.h
+++ b/src/v8runtime/V8Runtime.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cxxreact/MessageQueueThread.h>
 #include "V8RuntimeConfig.h"
 #include "jsi/jsi.h"
 #include "libplatform/libplatform.h"
@@ -20,7 +21,8 @@ class InspectorClient;
 
 class V8Runtime : public facebook::jsi::Runtime {
  public:
-  V8Runtime(std::unique_ptr<V8RuntimeConfig> config);
+  V8Runtime(std::unique_ptr<V8RuntimeConfig> config, 
+  std::shared_ptr<facebook::react::MessageQueueThread> jsQueue);
   V8Runtime(
       const V8Runtime *v8Runtime,
       std::unique_ptr<V8RuntimeConfig> config);
@@ -202,6 +204,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   std::shared_ptr<InspectorClient> inspectorClient_;
   bool isRegisteredIdleTaskRunner_ = false;
   bool isSharedRuntime_ = false;
+  std::shared_ptr<facebook::react::MessageQueueThread> jsQueue;
 };
 
 } // namespace rnv8

--- a/src/v8runtime/V8Runtime.h
+++ b/src/v8runtime/V8Runtime.h
@@ -204,7 +204,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   std::shared_ptr<InspectorClient> inspectorClient_;
   bool isRegisteredIdleTaskRunner_ = false;
   bool isSharedRuntime_ = false;
-  std::shared_ptr<facebook::react::MessageQueueThread> jsQueue;
+  std::shared_ptr<facebook::react::MessageQueueThread> jsQueue_;
 };
 
 } // namespace rnv8

--- a/src/v8runtime/V8RuntimeFactory.cpp
+++ b/src/v8runtime/V8RuntimeFactory.cpp
@@ -12,8 +12,9 @@
 namespace rnv8 {
 
 std::unique_ptr<facebook::jsi::Runtime> createV8Runtime(
-    std::unique_ptr<V8RuntimeConfig> config) {
-  return std::make_unique<V8Runtime>(std::move(config));
+    std::unique_ptr<V8RuntimeConfig> config,
+    std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) {
+  return std::make_unique<V8Runtime>(std::move(config), jsQueue);
 }
 
 std::unique_ptr<facebook::jsi::Runtime> createSharedV8Runtime(

--- a/src/v8runtime/V8RuntimeFactory.h
+++ b/src/v8runtime/V8RuntimeFactory.h
@@ -10,11 +10,12 @@
 #include <memory.h>
 #include "V8RuntimeConfig.h"
 #include "jsi/jsi.h"
+#include <cxxreact/MessageQueueThread.h>
 
 namespace rnv8 {
 
 std::unique_ptr<facebook::jsi::Runtime> createV8Runtime(
-    std::unique_ptr<V8RuntimeConfig> config);
+    std::unique_ptr<V8RuntimeConfig> config, std::shared_ptr<facebook::react::MessageQueueThread> jsQueue);
 
 std::unique_ptr<facebook::jsi::Runtime> createSharedV8Runtime(
     const facebook::jsi::Runtime *sharedRuntime,


### PR DESCRIPTION
I found out that v8::CpuProfiler keeps some threadLocal stuff and current implementation is calling it from a wrong thread.
It made profiler to return empty profiles. This pr is supposed to fix it. 