### PR TITLE
Fix StringView value when running devtool message on JS thread

### DIFF
--- a/src/v8runtime/V8Inspector.cpp
+++ b/src/v8runtime/V8Inspector.cpp
@@ -246,24 +246,20 @@ void InspectorClient::DispatchProxy(const std::string &message) {
   auto messageObj = folly::parseJson(message);
   auto method = messageObj["method"].asString();
 
-  v8_inspector::StringView messageView(
-          reinterpret_cast<const uint8_t *>(normalizedString.data()),
-          normalizedString.size());
-
   // For `v8::CpuProfiler` or some other modules with thread local storage, we should dispatch messages in the js thread.
   if (method == "Profiler.start" || method == "Profiler.stop") {
-    jsQueue_->runOnQueue([this, messageView]() {
+    jsQueue_->runOnQueue([this, normalizedString]() {
         v8::Isolate *isolate = GetIsolate();
         v8::Locker locker(isolate);
         v8::Isolate::Scope scopedIsolate(isolate);
         v8::HandleScope scopedHandle(isolate);
         v8::Context::Scope scopedContext(GetContext().Get(isolate));
-        session_->dispatchProtocolMessage(messageView);
+        session_->dispatchProtocolMessage(ToStringView(normalizedString));
     });
     return;
   }
 
-  session_->dispatchProtocolMessage(messageView);
+  session_->dispatchProtocolMessage(ToStringView(normalizedString));
 }
 
 void InspectorClient::DispatchProtocolMessage(const std::string &message) {


### PR DESCRIPTION
After testing devtools profiler in a large app, we noticed that the profiler stop command would crash with an invalid JSON message error. Upon inspection, what happens is the value of `messageView` when inside the `runOnQueue` closure is no longer the right value, which then fails to parse as JSON in the v8 code.

I think StringView is associated to a v8 scope, which would cause it to be garbage collected at the end of the function. Passing the std::string to the closure instead fixes the problem.