### PR TITLE
Fix duplicated libjsinspector.so

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -183,6 +183,7 @@ android {
       "**/libfolly_json.so",
       "**/libglog.so",
       "**/libreactnativejni.so",
+      "**/libjsinspector.so",
     ]
     pickFirst "**/libv8android.so"
   }


### PR DESCRIPTION
from #121 we linked `libjsinspector.so` and AGP sometimes would implicitly add the linked libs and cause duplicated lib issues.
fix #123 