### PR TITLE
Add react-native 0.69 support

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        rn-version: [0.68, 0.67]
+        rn-version: [0.69, 0.68]
         v8-android-variant:
           [v8-android-jit, v8-android-jit-nointl, v8-android, v8-android-nointl]
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,6 +25,15 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Restore yarn caches
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-workspace-modules-${{ hashFiles('yarn.lock') }}
+
+      - name: Yarn install
+        run: yarn install --frozen-lockfile
+
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_MEMRCHR=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_MEMRCHR=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION} -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare")
 
 # if(${NATIVE_DEBUG})
 #   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
@@ -30,8 +30,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 set(PACKAGE_NAME "v8executor")
 set(SRC_DIR "${CMAKE_SOURCE_DIR}/src/main/cpp")
 
-set(RN_SO_DIR "${RN_DIR}/ReactAndroid/src/main/jni/first-party/react/jni")
-set(FBJNI_HEADERS_DIR "${RN_SO_DIR}/../../fbjni/headers")
+set(FBJNI_HEADERS_DIR "${RN_DIR}/ReactAndroid/src/main/jni/first-party/fbjni/headers")
 
 set(V8RUNTIME_COMMON_DIR "${CMAKE_SOURCE_DIR}/../src/v8runtime")
 file(GLOB SOURCES_V8RUNTIME  "${V8RUNTIME_COMMON_DIR}/*.cpp")
@@ -66,19 +65,28 @@ target_include_directories(
 
 # find libraries
 
-file(GLOB LIBRN_DIR "${RN_SO_DIR}/${ANDROID_ABI}")
-file(GLOB LIBV8_DIR "${RN_SO_DIR}/../../v8/jni/${ANDROID_ABI}")
+file(GLOB LIBRN_DIR "${SO_DIR}/react/jni/${ANDROID_ABI}")
+file(GLOB LIBV8_DIR "${SO_DIR}/v8/jni/${ANDROID_ABI}")
 
 find_library(
   LOG_LIB
   log
 )
-find_library(
-  FOLLY_JSON_LIB
-  folly_json
-  PATHS ${LIBRN_DIR}
-  NO_CMAKE_FIND_ROOT_PATH
-)
+if(${REACT_NATIVE_TARGET_VERSION} LESS 69)
+  find_library(
+    FOLLY_LIB
+    folly_json
+    PATHS ${LIBRN_DIR}
+    NO_CMAKE_FIND_ROOT_PATH
+  )
+else()
+  find_library(
+    FOLLY_LIB
+    folly_runtime
+    PATHS ${LIBRN_DIR}
+    NO_CMAKE_FIND_ROOT_PATH
+  )
+endif()
 find_library(
   REACT_NATIVE_JNI_LIB
   reactnativejni
@@ -144,7 +152,7 @@ target_include_directories(
 
 target_link_libraries(
   reactnative_internal_static
-  ${FOLLY_JSON_LIB}
+  ${FOLLY_LIB}
 )
 
 # link to shared libraries
@@ -158,7 +166,7 @@ target_link_libraries(
   ${JSINSPECTOR_LIB}
   ${GLOG_LIB}
   ${FBJNI_LIB}
-  ${FOLLY_JSON_LIB}
+  ${FOLLY_LIB}
   ${REACT_NATIVE_JNI_LIB}
   ${V8_ANDROID_LIB}
   reactnative_internal_static

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * Copyright (c) Software Mansion <swmansion.com>.
+ * Copyright (c) 650 Industries.
  * Copyright (c) Kudo Chien.
  *
  * This source code is licensed under the MIT license found in the
@@ -32,6 +33,7 @@ def reactNativeManifestAsJson = new JsonSlurper().parseText(reactNativeManifest.
 def reactNativeVersion = reactNativeManifestAsJson.version as String
 def (major, minor, patch) = reactNativeVersion.tokenize('.')
 def rnMinorVersion = Integer.parseInt(minor)
+def extractSoDir = "${buildDir}/jniLibs"
 
 def findV8AndroidDir() {
   def v8Packages = [
@@ -156,7 +158,9 @@ android {
                   "-DBOOST_VERSION=${BOOST_VERSION}",
                   "-DBUILD_DIR=${buildDir}",
                   "-DRN_DIR=${reactNativeDir}",
-                  "-DV8_ANDROID_DIR=${v8AndroidDir}"
+                  "-DREACT_NATIVE_TARGET_VERSION=${rnMinorVersion}",
+                  "-DV8_ANDROID_DIR=${v8AndroidDir}",
+                  "-DSO_DIR=${extractSoDir}"
         abiFilters (*reactNativeArchitectures())
         _stackProtectorFlag ? (cppFlags("-fstack-protector-all")) : null
       }
@@ -197,7 +201,7 @@ android {
   }
   sourceSets {
     main {
-      jniLibs.srcDirs = ["${reactNativeDir}/ReactAndroid/src/main/jni/first-party/v8/jni"]
+      jniLibs.srcDirs = ["${extractSoDir}/v8/jni"]
 
       if (v8UseSnapshot) {
         assets.srcDirs += [ "${v8AndroidDir}/dist/snapshot_blob" ]
@@ -223,7 +227,12 @@ task createNativeDepsDirectories() {
 }
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-  src("https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz")
+  def transformedVersion = BOOST_VERSION.replace("_", ".")
+  def srcUrl = "https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"
+  if (rnMinorVersion < 69) {
+    srcUrl = "https://github.com/react-native-community/boost-for-react-native/releases/download/v${transformedVersion}-0/boost_${BOOST_VERSION}.tar.gz"
+  }
+  src(srcUrl)
   onlyIfNewer(true)
   overwrite(false)
   dest(new File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz"))
@@ -318,6 +327,43 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
   }
 }
 
+def extractReactNativeAAR = { buildType ->
+  def suffix = buildType == 'Debug' ? '-debug' : '-release'
+  def rnAARs = fileTree("${reactNativeDir}/android").matching { include "**/react-native/**/*${suffix}.aar" }
+  if (rnAARs.isEmpty()) {
+    rnAARs = fileTree("${reactNativeDir}/android").matching { include "**/react-native/**/*.aar" }
+  }
+  if (rnAARs.any()) {
+    // node_modules/react-native has a .aar, extract headers
+    if (rnAARs.size() > 1) {
+      logger.error("More than one React Native AAR file has been found:")
+      rnAARs.each {println(it) }
+      throw new GradleException("Multiple React Native AARs found:\n${rnAARs.join("\n")}" +
+          "\nRemove the old ones and try again")
+    }
+  }
+  def rnAAR = rnAARs.singleFile
+  def file = rnAAR.absoluteFile
+  def packageName = file.name.tokenize('-')[0]
+  copy {
+    from zipTree(file)
+    into "${extractSoDir}/${packageName}"
+    include "jni/**/*"
+  }
+}
+
+task extractReactNativeAARRelease {
+  doLast {
+    extractReactNativeAAR('Release')
+  }
+}
+
+task extractReactNativeAARDebug {
+  doLast {
+    extractReactNativeAAR('Debug')
+  }
+}
+
 task extractAARHeaders {
   doLast {
     configurations.extractHeaders.files.each {
@@ -339,7 +385,7 @@ task extractSOFiles {
       def packageName = file.name.tokenize('-')[0]
       copy {
         from zipTree(file)
-        into "${reactNativeDir}/ReactAndroid/src/main/jni/first-party/${packageName}/"
+        into "${extractSoDir}/${packageName}"
         include "jni/**/*.so"
       }
     }
@@ -354,9 +400,6 @@ dependencies {
 
   extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
   extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
-
-  def rnAAR = fileTree("${reactNativeDir}/android").matching({ it.include "**/**/*.aar" }).singleFile
-  extractSO(files(rnAAR))
 
   def v8AAR = fileTree("${v8AndroidDir}/dist").matching({ it.include "**/**/*.aar" }).singleFile
   extractSO(files(v8AAR))
@@ -375,6 +418,7 @@ task prepareThirdPartyNdkHeaders(dependsOn:[downloadNdkBuildDependencies, prepar
 }
 
 tasks.whenTaskAdded { task ->
+  def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
   if (
       !task.name.contains("Clean") && (
         task.name.startsWith("externalNativeBuild")
@@ -385,6 +429,9 @@ tasks.whenTaskAdded { task ->
     extractAARHeaders.dependsOn(prepareThirdPartyNdkHeaders)
     extractSOFiles.dependsOn(prepareThirdPartyNdkHeaders)
     task.dependsOn(extractAARHeaders)
+    task.dependsOn(extractSOFiles)
+    task.dependsOn("extractReactNativeAAR${buildType}")
+  } else if (task.name == "merge${buildType}JniLibFolders") {
     task.dependsOn(extractSOFiles)
   }
 }

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -572,6 +572,23 @@ jsi::PropNameID V8Runtime::createPropNameIDFromString(const jsi::String &str) {
       reinterpret_cast<const uint8_t *>(*utf8), utf8.length());
 }
 
+#if REACT_NATIVE_TARGET_VERSION >= 69
+jsi::PropNameID V8Runtime::createPropNameIDFromSymbol(
+    const facebook::jsi::Symbol &sym) {
+  v8::Locker locker(isolate_);
+  v8::Isolate::Scope scopedIsolate(isolate_);
+  v8::HandleScope scopedHandle(isolate_);
+  v8::Context::Scope scopedContext(context_.Get(isolate_));
+
+  const V8PointerValue *v8PointerValue =
+      static_cast<const V8PointerValue *>(getPointerValue(sym));
+  assert(v8PointerValue->Get(isolate_)->IsSymbol());
+
+  return make<jsi::PropNameID>(
+      const_cast<PointerValue *>(getPointerValue(sym)));
+}
+#endif
+
 std::string V8Runtime::utf8(const jsi::PropNameID &sym) {
   v8::Locker locker(isolate_);
   v8::Isolate::Scope scopedIsolate(isolate_);

--- a/src/v8runtime/V8Runtime.h
+++ b/src/v8runtime/V8Runtime.h
@@ -85,6 +85,10 @@ class V8Runtime : public facebook::jsi::Runtime {
       size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromString(
       const facebook::jsi::String &str) override;
+#if REACT_NATIVE_TARGET_VERSION >= 69
+  facebook::jsi::PropNameID createPropNameIDFromSymbol(
+      const facebook::jsi::Symbol &sym) override;
+#endif
   std::string utf8(const facebook::jsi::PropNameID &) override;
   bool compare(
       const facebook::jsi::PropNameID &,


### PR DESCRIPTION
# Why

add react-native 0.69 support

# How

- react-native 0.69 includes multiple AARs, extract correct AAR for linking.
- react-native 0.69 changes `libfolly_json.so` to `libfolly_runtime.so`.
- react-native 0.69 adds `createPropNameIDFromSymbol` for jsi.
- react-native 0.69 changes boost download location.
- a little refactor for extract so location in building time.

# Test Plan

ci passed

Co-authored-by: Ammar Ahmed