### PR TITLE
exclude auto linked libfolly_runtime.so

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -194,6 +194,7 @@ android {
       "**/libfbjni.so",
       "**/libjsi.so",
       "**/libfolly_json.so",
+      "**/libfolly_runtime.so",
       "**/libglog.so",
       "**/libreactnativejni.so",
       "**/libjsinspector.so",


### PR DESCRIPTION
# Why

fix #136 