### PR TITLE
Add `REACT_NATIVE_DOWNLOADS_DIR` to specify custom download location

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -113,7 +113,8 @@ def FBJNI_VERSION = "0.3.0"
 // We then copy both the downloaded code and our custom makefiles and headers into third-party-ndk.
 // After that we build native code from src/main/jni with module path pointing at third-party-ndk.
 
-def downloadsDir = new File("${buildDir}/downloads")
+def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
+def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("${buildDir}/downloads")
 def thirdPartyNdkDir = new File("${buildDir}/third-party-ndk")
 
 def reactNativeThirdPartyDir = new File("${reactNativeDir}/ReactAndroid/src/main/jni/third-party")


### PR DESCRIPTION
# Why

it's not ideal for an app to download 3rd party libraries multiple times.

# How

add `REACT_NATIVE_DOWNLOADS_DIR` environment variable to support custom download location. the way is aligned with [react-native](https://github.com/facebook/react-native/blob/37d0a25cb28879449d89056079c94177c7d2c73f/ReactAndroid/build.gradle#L34-L35) 