### PR TITLE
alternative solution for pumping v8 message loop

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -60,6 +60,7 @@ target_include_directories(
   "${RN_DIR}/ReactCommon"
   "${RN_DIR}/ReactCommon/jsi"
   "${RN_DIR}/ReactCommon/jsiexecutor"
+  "${RN_DIR}/ReactCommon/runtimeexecutor"
   "${V8_ANDROID_DIR}/dist/include"
 )
 
@@ -118,6 +119,12 @@ find_library(
   NO_CMAKE_FIND_ROOT_PATH
 )
 find_library(
+  RUNTIMEEXECUTOR_LIB
+  runtimeexecutor
+  PATHS ${LIBRN_DIR}
+  NO_CMAKE_FIND_ROOT_PATH
+)
+find_library(
   V8_ANDROID_LIB
   v8android
   PATHS ${LIBV8_DIR}
@@ -168,6 +175,7 @@ target_link_libraries(
   ${FBJNI_LIB}
   ${FOLLY_LIB}
   ${REACT_NATIVE_JNI_LIB}
+  ${RUNTIMEEXECUTOR_LIB}
   ${V8_ANDROID_LIB}
   reactnative_internal_static
   android

--- a/android/src/main/java/io/csie/kudo/reactnative/v8/ReactNativeV8Package.java
+++ b/android/src/main/java/io/csie/kudo/reactnative/v8/ReactNativeV8Package.java
@@ -17,11 +17,13 @@ import com.facebook.react.uimanager.ViewManager;
 import java.util.Collections;
 import java.util.List;
 
+import io.csie.kudo.reactnative.v8.executor.V8Module;
+
 public class ReactNativeV8Package implements ReactPackage {
   @NonNull
   @Override
   public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
-    return Collections.emptyList();
+    return Collections.singletonList(new V8Module(reactContext));
   }
 
   @NonNull

--- a/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Executor.java
+++ b/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Executor.java
@@ -12,6 +12,7 @@ import android.content.res.AssetManager;
 import android.os.Build;
 import com.facebook.jni.HybridData;
 import com.facebook.react.bridge.JavaScriptExecutor;
+import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.soloader.SoLoader;
 import io.csie.kudo.reactnative.v8.BuildConfig;
 import java.io.File;
@@ -66,4 +67,7 @@ public class V8Executor extends JavaScriptExecutor {
       String snapshotBlobPath,
       int codecacheMode,
       String codecachePath);
+
+  /* package */ static native void onMainLoopIdle(
+      RuntimeExecutor runtimeExecutor);
 }

--- a/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Module.java
+++ b/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Module.java
@@ -1,0 +1,66 @@
+package io.csie.kudo.reactnative.v8.executor;
+
+import android.os.Build;
+import android.os.Looper;
+import android.os.MessageQueue;
+import android.os.SystemClock;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.RuntimeExecutor;
+import com.facebook.react.bridge.UiThreadUtil;
+
+public class V8Module
+    extends ReactContextBaseJavaModule implements MessageQueue.IdleHandler {
+  private long mLastMainLoopIdleCallbackTime = 0;
+  private static final long MAIN_LOOP_IDLE_THROTTLE = 1000;
+
+  public V8Module(ReactApplicationContext reactContext) {
+    super(reactContext);
+    registerMainIdleHandler();
+  }
+
+  @Override
+  public void onCatalystInstanceDestroy() {
+    super.onCatalystInstanceDestroy();
+    unregisterMainIdleHandler();
+  }
+
+  @Override
+  public String getName() {
+    return "V8Module";
+  }
+
+  private void registerMainIdleHandler() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      Looper.getMainLooper().getQueue().addIdleHandler(this);
+    } else {
+      UiThreadUtil.runOnUiThread(
+          () -> { Looper.myQueue().addIdleHandler(this); });
+    }
+  }
+
+  private void unregisterMainIdleHandler() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      Looper.getMainLooper().getQueue().removeIdleHandler(this);
+    } else {
+      UiThreadUtil.runOnUiThread(
+          () -> { Looper.myQueue().removeIdleHandler(this); });
+    }
+  }
+
+  // MessageQueue.IdleHandler implementations
+
+  @Override
+  public boolean queueIdle() {
+    if (getReactApplicationContext().hasActiveReactInstance() &&
+        SystemClock.uptimeMillis() - mLastMainLoopIdleCallbackTime >
+            MAIN_LOOP_IDLE_THROTTLE) {
+      final RuntimeExecutor runtimeExecutor = getReactApplicationContext()
+                                                  .getCatalystInstance()
+                                                  .getRuntimeExecutor();
+      V8Executor.onMainLoopIdle(runtimeExecutor);
+      mLastMainLoopIdleCallbackTime = SystemClock.uptimeMillis();
+    }
+    return true;
+  }
+}

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -84,8 +84,6 @@ V8Runtime::V8Runtime(
     std::unique_ptr<V8RuntimeConfig> config)
     : config_(std::move(config)) {
   isSharedRuntime_ = true;
-  // We don't need to register another idle taskrunner again
-  isRegisteredIdleTaskRunner_ = true;
   isolate_ = v8Runtime->isolate_;
   jsQueue_ = v8Runtime->jsQueue_;
 
@@ -136,6 +134,20 @@ V8Runtime::~V8Runtime() {
   }
   // v8::V8::Dispose();
   // v8::V8::DisposePlatform();
+}
+
+void V8Runtime::OnMainLoopIdle() {
+  v8::Locker locker(isolate_);
+  v8::Isolate::Scope scopedIsolate(isolate_);
+  v8::HandleScope scopedHandle(isolate_);
+  v8::Context::Scope scopedContext(context_.Get(isolate_));
+
+  while (v8::platform::PumpMessageLoop(
+      s_platform.get(),
+      isolate_,
+      v8::platform::MessageLoopBehavior::kDoNotWait)) {
+    continue;
+  }
 }
 
 v8::Local<v8::Context> V8Runtime::CreateGlobalContext(v8::Isolate *isolate) {
@@ -197,53 +209,7 @@ jsi::Value V8Runtime::ExecuteScript(
     return {};
   }
 
-  RegisterIdleTaskRunnerIfNeeded();
-
   return JSIV8ValueConverter::ToJSIValue(isolate, result);
-}
-
-void V8Runtime::RegisterIdleTaskRunnerIfNeeded() {
-  if (isRegisteredIdleTaskRunner_) {
-    return;
-  }
-
-  global().setProperty(
-      *this,
-      "__v8OnIdleCallback",
-      jsi::Function::createFromHostFunction(
-          *this,
-          jsi::PropNameID::forAscii(*this, "__v8OnIdleCallback"),
-          0,
-          [](jsi::Runtime &runtime,
-             jsi::Value const &thisValue,
-             const jsi::Value *args,
-             size_t count) {
-            V8Runtime *v8Runtime = dynamic_cast<V8Runtime *>(&runtime);
-            v8Runtime->OnIdle();
-            return jsi::Value();
-          }));
-  global()
-      .getPropertyAsFunction(*this, "requestIdleCallback")
-      .call(*this, global().getPropertyAsFunction(*this, "__v8OnIdleCallback"));
-
-  isRegisteredIdleTaskRunner_ = true;
-}
-
-void V8Runtime::OnIdle() {
-  v8::Locker locker(isolate_);
-  v8::Isolate::Scope scopedIsolate(isolate_);
-  v8::HandleScope scopedHandle(isolate_);
-  v8::Context::Scope scopedContext(context_.Get(isolate_));
-
-  while (v8::platform::PumpMessageLoop(
-      s_platform.get(),
-      isolate_,
-      v8::platform::MessageLoopBehavior::kDoNotWait)) {
-    continue;
-  }
-  global()
-      .getPropertyAsFunction(*this, "requestIdleCallback")
-      .call(*this, global().getPropertyAsFunction(*this, "__v8OnIdleCallback"));
 }
 
 void V8Runtime::ReportException(v8::Isolate *isolate, v8::TryCatch *tryCatch)

--- a/src/v8runtime/V8Runtime.h
+++ b/src/v8runtime/V8Runtime.h
@@ -29,14 +29,15 @@ class V8Runtime : public facebook::jsi::Runtime {
       std::unique_ptr<V8RuntimeConfig> config);
   ~V8Runtime();
 
+  // Calling this function when the platform main runloop is idle
+  void OnMainLoopIdle();
+
  private:
   v8::Local<v8::Context> CreateGlobalContext(v8::Isolate *isolate);
   facebook::jsi::Value ExecuteScript(
       v8::Isolate *isolate,
       const v8::Local<v8::String> &script,
       const std::string &sourceURL);
-  void RegisterIdleTaskRunnerIfNeeded();
-  void OnIdle();
   void ReportException(v8::Isolate *isolate, v8::TryCatch *tryCatch) const;
 
   std::unique_ptr<v8::ScriptCompiler::CachedData> LoadCodeCacheIfNeeded(
@@ -215,7 +216,6 @@ class V8Runtime : public facebook::jsi::Runtime {
   v8::Isolate *isolate_;
   v8::Global<v8::Context> context_;
   std::shared_ptr<InspectorClient> inspectorClient_;
-  bool isRegisteredIdleTaskRunner_ = false;
   bool isSharedRuntime_ = false;
   std::shared_ptr<facebook::react::MessageQueueThread> jsQueue_;
 };


### PR DESCRIPTION
# Why

originally, we pump v8 message loop by `requestIdleCallback` provided by react-native. this will block detox testing because detox detects the app idle state by the internal queue shared with the `requestIdleCallback`. then detox testing will hang.

# How

use the android `Looper.getMainLooper().getQueue().addIdleHandler()` to listen when main runloop is idle and call the c++ code through the native module and runtime executor.

# Test Plan

- ci passed
- test compatibility with reanimated
- test compatibility with detox