### PR TITLE
suppress unused-variable warning

### DIFF
--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -576,6 +576,9 @@ jsi::PropNameID V8Runtime::createPropNameIDFromSymbol(
       static_cast<const V8PointerValue *>(getPointerValue(sym));
   assert(v8PointerValue->Get(isolate_)->IsSymbol());
 
+  // suppress unused-variable warning
+  (void)v8PointerValue;
+
   return make<jsi::PropNameID>(
       const_cast<PointerValue *>(getPointerValue(sym)));
 }

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -572,12 +572,7 @@ jsi::PropNameID V8Runtime::createPropNameIDFromSymbol(
   v8::HandleScope scopedHandle(isolate_);
   v8::Context::Scope scopedContext(context_.Get(isolate_));
 
-  const V8PointerValue *v8PointerValue =
-      static_cast<const V8PointerValue *>(getPointerValue(sym));
-  assert(v8PointerValue->Get(isolate_)->IsSymbol());
-
-  // suppress unused-variable warning
-  (void)v8PointerValue;
+  assert(static_cast<const V8PointerValue *>(getPointerValue(sym))->Get(isolate_)->IsSymbol());
 
   return make<jsi::PropNameID>(
       const_cast<PointerValue *>(getPointerValue(sym)));


### PR DESCRIPTION
On branch [0.69-v8](https://github.com/Sunbreak/react-native/tree/0.69-v8) of https://github.com/Sunbreak/react-native, when bundleReleaseAar

```
$ ./gradlew :ReactAndroid:bundleReleaseAar
ReactCommon/jsi/v8runtime/V8Runtime.cpp:582:25: error: unused variable 'v8PointerValue' [-Werror,-Wunused-variable]
    const V8PointerValue *v8PointerValue =
                          ^
  1 error generated.
```