### PR TITLE
Exclude libruntimeexecutor.so from cmake auto linking

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -204,6 +204,7 @@ android {
       "**/libglog.so",
       "**/libreactnativejni.so",
       "**/libjsinspector.so",
+      "**/libruntimeexecutor.so",
     ]
     pickFirst "**/libv8android.so"
   }


### PR DESCRIPTION
# Why

fix #144

# How

regression from #141 where it introduces _libruntimeexecutor.so_ links but does not exclude it from gradle. that would cause build errors on linux.