### PR TITLE
Improve onMainLoopIdle stability

### DIFF
--- a/android/src/main/cpp/OnLoad.cpp
+++ b/android/src/main/cpp/OnLoad.cpp
@@ -102,8 +102,10 @@ class V8ExecutorHolder
       jni::alias_ref<facebook::react::JRuntimeExecutor::javaobject>
           runtimeExecutor) {
     runtimeExecutor->cthis()->get()([](jsi::Runtime &runtime) {
-      auto &v8Runtime = reinterpret_cast<V8Runtime &>(runtime);
-      v8Runtime.OnMainLoopIdle();
+      auto v8Runtime = dynamic_cast<V8Runtime *>(&runtime);
+      if (v8Runtime) {
+        v8Runtime->OnMainLoopIdle();
+      }
     });
   }
 

--- a/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Module.java
+++ b/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Module.java
@@ -21,8 +21,8 @@ public class V8Module
 
   @Override
   public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
     unregisterMainIdleHandler();
+    super.onCatalystInstanceDestroy();
   }
 
   @Override


### PR DESCRIPTION
- unregister the listener before native module destroy
- check the runtime from `RuntimeExecutor` is `V8Runtime`