### PR TITLE
Fix build error on RN 0.66 and 0.67

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        rn-version: ['0.70', '0.69']
+        rn-version: ['0.70']
         v8-android-variant:
           [v8-android-jit, v8-android-jit-nointl, v8-android, v8-android-nointl]
         include:
-          - rn-version: '0.68'
+          - rn-version: ['0.69', '0.68', '0.67', '0.66']
             v8-android-variant: v8-android-jit
 
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   e2e-test:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     strategy:
       matrix:
         rn-version: ['0.70']

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,13 @@ jobs:
         v8-android-variant:
           [v8-android-jit, v8-android-jit-nointl, v8-android, v8-android-nointl]
         include:
-          - rn-version: ['0.69', '0.68', '0.67', '0.66']
+          - rn-version: '0.69'
+            v8-android-variant: v8-android-jit
+          - rn-version: '0.68'
+            v8-android-variant: v8-android-jit
+          - rn-version: '0.67'
+            v8-android-variant: v8-android-jit
+          - rn-version: '0.66'
             v8-android-variant: v8-android-jit
 
     steps:

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -118,12 +118,16 @@ find_library(
   PATHS ${LIBRN_DIR}
   NO_CMAKE_FIND_ROOT_PATH
 )
-find_library(
-  RUNTIMEEXECUTOR_LIB
-  runtimeexecutor
-  PATHS ${LIBRN_DIR}
-  NO_CMAKE_FIND_ROOT_PATH
-)
+if(${REACT_NATIVE_TARGET_VERSION} GREATER_EQUAL 68)
+  find_library(
+    RUNTIMEEXECUTOR_LIB
+    runtimeexecutor
+    PATHS ${LIBRN_DIR}
+    NO_CMAKE_FIND_ROOT_PATH
+  )
+else()
+  set(RUNTIMEEXECUTOR_LIB "")
+endif()
 find_library(
   V8_ANDROID_LIB
   v8android


### PR DESCRIPTION
# Why

fix #149 

# How

runtimexecutor is a shared library after rn 0.68. for 0.66 and 0.67, reactnativejni includes the symbols.

# Test Plan

add 0.66 and 0.67 to ci testing