### PR TITLE
Fix expo integration on android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,7 +58,7 @@ jobs:
           script: |
             adb logcat -c
             python3 scripts/gen_project.py --rn-version ${{ matrix.rn-version }} --v8-android-variant ${{ matrix.v8-android-variant }} TestApp
-            sleep 5
+            sleep 10
             adb logcat -d > TestApp/adb.log
             grep -E "=== V8 version\[.+\] ===" TestApp/adb.log > /dev/null
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: E2E tests for Android
+name: E2E tests on bare React Native Android project
 
 on:
   push:
@@ -52,7 +52,7 @@ jobs:
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: 33
           script: |
             adb logcat -c
             python3 scripts/gen_project.py --rn-version ${{ matrix.rn-version }} --v8-android-variant ${{ matrix.v8-android-variant }} TestApp

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,6 +53,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 33
+          arch: x86_64
+          target: google_apis
           script: |
             adb logcat -c
             python3 scripts/gen_project.py --rn-version ${{ matrix.rn-version }} --v8-android-variant ${{ matrix.v8-android-variant }} TestApp

--- a/.github/workflows/expo-android.yml
+++ b/.github/workflows/expo-android.yml
@@ -1,0 +1,83 @@
+name: E2E tests on Expo Android project
+
+on:
+  push:
+    branches: [main, '*-stable']
+    paths:
+      - .github/workflows/expo-android.yml
+      - android/**
+      - src/v8runtime/**
+      - package.json
+      - yarn.lock
+  pull_request:
+    paths:
+      - .github/workflows/expo-android.yml
+      - android/**
+      - src/v8runtime/**
+      - package.json
+      - yarn.lock
+
+jobs:
+  e2e-test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Restore yarn caches
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-workspace-modules-${{ hashFiles('yarn.lock') }}
+
+      - name: Yarn install
+        run: yarn install --frozen-lockfile
+
+      - name: Generate TestApp
+        run: |
+          yarn create expo-app TestApp
+          cd TestApp
+          yarn add v8-ios
+          yarn add file:../react-native-v8
+          jq '.expo.android.package = "com.testapp" | .expo.plugins += ["react-native-v8"] | .expo.jsEngine = "jsc"' app.json > app.json.tmp && mv -f app.json.tmp app.json
+          echo 'if (global._v8runtime) { console.log(`=== V8 version[${global._v8runtime().version}] ===`); }' >> App.js
+        working-directory: ..
+
+      - name: Build TestApp
+        working-directory: ../TestApp
+        run: |
+          npx expo prebuild -p android
+          cd android
+          ./gradlew :app:assembleRelease
+
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          working-directory: ../TestApp/android
+          script: |
+            adb install -r app/build/outputs/apk/release/app-release.apk
+            adb logcat -c
+            adb shell am start -n com.testapp/com.testapp.MainActivity
+            sleep 5
+            adb logcat -d > adb.log
+            grep -E "=== V8 version\[.+\] ===" adb.log > /dev/null
+
+      - name: Collect failure files
+        if: failure()
+        run: |
+          cp ../TestApp/android/adb.log .
+
+      - name: Upload failed artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: |
+            adb.log

--- a/.github/workflows/expo-android.yml
+++ b/.github/workflows/expo-android.yml
@@ -60,6 +60,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 33
+          arch: x86_64
+          target: google_apis
           working-directory: ../TestApp/android
           script: |
             adb install -r app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/expo-android.yml
+++ b/.github/workflows/expo-android.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           yarn create expo-app TestApp
           cd TestApp
-          yarn add v8-ios
+          yarn add v8-android-jit
           yarn add file:../react-native-v8
           jq '.expo.android.package = "com.testapp" | .expo.plugins += ["react-native-v8"] | .expo.jsEngine = "jsc"' app.json > app.json.tmp && mv -f app.json.tmp app.json
           echo 'if (global._v8runtime) { console.log(`=== V8 version[${global._v8runtime().version}] ===`); }' >> App.js

--- a/.github/workflows/expo-android.yml
+++ b/.github/workflows/expo-android.yml
@@ -67,7 +67,7 @@ jobs:
             adb install -r app/build/outputs/apk/release/app-release.apk
             adb logcat -c
             adb shell am start -n com.testapp/com.testapp.MainActivity
-            sleep 5
+            sleep 10
             adb logcat -d > adb.log
             grep -E "=== V8 version\[.+\] ===" adb.log > /dev/null
 

--- a/.github/workflows/expo-ios.yml
+++ b/.github/workflows/expo-ios.yml
@@ -1,17 +1,17 @@
-name: E2E tests for iOS
+name: E2E tests on Expo iOS project
 
 on:
   push:
     branches: [main, '*-stable']
     paths:
-      - .github/workflows/ios.yml
+      - .github/workflows/expo-ios.yml
       - src/iosexecutor/**
       - src/v8runtime/**
       - package.json
       - yarn.lock
   pull_request:
     paths:
-      - .github/workflows/ios.yml
+      - .github/workflows/expo-ios.yml
       - src/iosexecutor/**
       - src/v8runtime/**
       - package.json
@@ -73,6 +73,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts-${{ matrix.rn-version }}-${{ matrix.v8-android-variant }}
+          name: artifacts
           path: |
             sim.log

--- a/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8ExecutorFactory.java
+++ b/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8ExecutorFactory.java
@@ -84,4 +84,16 @@ public class V8ExecutorFactory implements JavaScriptExecutorFactory {
     }
     return null;
   }
+
+  /**
+   * For Expo integration where we cannot get exact `getBundleAssetName`,
+   * use a hardcoded **index.android.bundle** default name instead.
+   */
+  @Nullable
+  public static String getBundleAssetName(
+      final Context context,
+      final boolean useDeveloperSupport) {
+    return getV8BundleAssetName(
+        context, "index.android.bundle", useDeveloperSupport);
+  }
 }


### PR DESCRIPTION
# Why

fixes #168

# How

- this is a regression from #165. i would add the original `getBundleAssetName` back.
- add expo android project ci job

# Test Plan

ci passed