### PR TITLE
[ci] try to make ci test stable

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           api-level: 33
           arch: x86_64
-          target: google_apis
+          target: google_apis_playstore
           script: |
             adb logcat -c
             python3 scripts/gen_project.py --rn-version ${{ matrix.rn-version }} --v8-android-variant ${{ matrix.v8-android-variant }} TestApp

--- a/.github/workflows/expo-android.yml
+++ b/.github/workflows/expo-android.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           api-level: 33
           arch: x86_64
-          target: google_apis
+          target: google_apis_playstore
           working-directory: ../TestApp/android
           script: |
             adb install -r app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
use `google_apis_playstore` api 33 image and it looks like more stable