### PR TITLE
[feat] add expo plugin config options

### DIFF
--- a/plugin/build/withV8ExpoAdapter.d.ts
+++ b/plugin/build/withV8ExpoAdapter.d.ts
@@ -1,5 +1,9 @@
 import type { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void>;
+export type PluginOptions = {
+    android?: boolean;
+    ios?: boolean;
+};
+declare const _default: ConfigPlugin<PluginOptions>;
 export default _default;
 /**
  * Updates **android/app/build.gradle** to add the packaging options

--- a/plugin/build/withV8ExpoAdapter.js
+++ b/plugin/build/withV8ExpoAdapter.js
@@ -3,9 +3,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.updateIosAppDelegate = exports.updateAndroidAppGradle = void 0;
 const config_plugins_1 = require("expo/config-plugins");
 const generateCode_1 = require("./generateCode");
-const withV8ExpoAdapter = (config) => {
-    config = withAndroidGradles(config);
-    config = withIosAppDelegate(config);
+const withV8ExpoAdapter = (config, opts) => {
+    const { android = true, ios = true } = opts ?? {};
+    if (android) {
+        config = withAndroidGradles(config);
+    }
+    if (ios) {
+        config = withIosAppDelegate(config);
+    }
     return config;
 };
 const pkg = require('react-native-v8/package.json');

--- a/plugin/src/withV8ExpoAdapter.ts
+++ b/plugin/src/withV8ExpoAdapter.ts
@@ -4,9 +4,19 @@ import type { ConfigPlugin } from 'expo/config-plugins';
 
 import { mergeContents, MergeResults } from './generateCode';
 
-const withV8ExpoAdapter: ConfigPlugin = (config) => {
-  config = withAndroidGradles(config);
-  config = withIosAppDelegate(config);
+export type PluginOptions = {
+  android?: boolean;
+  ios?: boolean;
+}
+
+const withV8ExpoAdapter: ConfigPlugin<PluginOptions> = (config, opts) => {
+  const { android = true, ios = true } = opts ?? {};
+  if (android) {
+    config = withAndroidGradles(config);
+  }
+  if (ios) {
+    config = withIosAppDelegate(config);
+  }
   return config;
 };
 


### PR DESCRIPTION
I'd like to be able to configure if v8 is applied to iOS build. I would expect to be able to configure like this in my expo app.config.js.

```
plugins: [
  ['react-native-v8', { android: true, ios: false }] 
]
```

Are you open to contributions?