### PR TITLE
Disable ios by default

### DIFF
--- a/.github/workflows/expo-ios.yml
+++ b/.github/workflows/expo-ios.yml
@@ -39,7 +39,7 @@ jobs:
           cd TestApp
           yarn add v8-ios
           yarn add file:../react-native-v8
-          jq '.expo.ios.bundleIdentifier = "com.testapp" | .expo.plugins += ["react-native-v8"] | .expo.jsEngine = "jsc"' app.json > app.json.tmp && mv -f app.json.tmp app.json
+          jq '.expo.ios.bundleIdentifier = "com.testapp" | .expo.plugins += [["react-native-v8", {"ios":true}]] | .expo.jsEngine = "jsc"' app.json > app.json.tmp && mv -f app.json.tmp app.json
           echo 'if (global._v8runtime) { console.log(`=== V8 version[${global._v8runtime().version}] ===`); }' >> App.js
         working-directory: ..
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo/",
     "!expo/build",
     "expo-module.config.json",
+    "react-native.config.js",
     "app.plugin.js",
     "plugin/",
     "RNV8.podspec",

--- a/plugin/build/withV8ExpoAdapter.js
+++ b/plugin/build/withV8ExpoAdapter.js
@@ -4,7 +4,7 @@ exports.updateIosAppDelegate = exports.updateAndroidAppGradle = void 0;
 const config_plugins_1 = require("expo/config-plugins");
 const generateCode_1 = require("./generateCode");
 const withV8ExpoAdapter = (config, opts) => {
-    const { android = true, ios = true } = opts ?? {};
+    const { android = true, ios = false } = opts ?? {};
     if (android) {
         config = withAndroidGradles(config);
     }

--- a/plugin/src/withV8ExpoAdapter.ts
+++ b/plugin/src/withV8ExpoAdapter.ts
@@ -10,7 +10,7 @@ export type PluginOptions = {
 }
 
 const withV8ExpoAdapter: ConfigPlugin<PluginOptions> = (config, opts) => {
-  const { android = true, ios = true } = opts ?? {};
+  const { android = true, ios = false } = opts ?? {};
   if (android) {
     config = withAndroidGradles(config);
   }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      // Only enable ios autolinking when v8-ios is installed
+      ios: !!require.resolve('v8-ios/package.json'),
+    },
+  },
+};

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,8 +1,16 @@
+const v8IosInstalled = (function() {
+ try {
+    return !!require.resolve('v8-ios/package.json');
+ } catch {
+    return false;
+ }
+})();
+
 module.exports = {
   dependency: {
     platforms: {
       // Only enable ios autolinking when v8-ios is installed
-      ios: !!require.resolve('v8-ios/package.json'),
+      ios: v8IosInstalled ? {} : null,
     },
   },
 };


### PR DESCRIPTION
# Why

considering ios is an advanced and experiment features, it's better to disable ios support by default.

# How

- [expo config-plugins] disable ios by default
- disable ios autolinking when `v8-ios` is not installed
- [ci] explicitly enable ios support for expo config-plugins