### PR TITLE
[plugin] fix support on expo sdk 49 (rn 0.72)

### DIFF
--- a/plugin/build/withV8ExpoAdapter.js
+++ b/plugin/build/withV8ExpoAdapter.js
@@ -60,11 +60,18 @@ function updateAndroidAppGradle(contents) {
 android {
     androidComponents {
         onVariants(selector().withBuildType('release')) {
+            packaging.jniLibs.pickFirsts.set([])
             packaging.jniLibs.excludes.add('**/**/libjsc*')
             packaging.jniLibs.excludes.add('**/**/libhermes*')
         }
+        onVariants(selector().withBuildType('debug')) {
+            packaging.jniLibs.pickFirsts.set([])
+            packaging.jniLibs.excludes.add('**/**/libjsc*')
+            packaging.jniLibs.pickFirsts.add('**/**/libhermes*')
+        }
     }
-}`;
+}
+`;
     let mergeResults;
     mergeResults = (0, generateCode_1.mergeContents)({
         tag: mergeTag,

--- a/plugin/src/withV8ExpoAdapter.ts
+++ b/plugin/src/withV8ExpoAdapter.ts
@@ -73,11 +73,18 @@ export function updateAndroidAppGradle(contents: string): string {
 android {
     androidComponents {
         onVariants(selector().withBuildType('release')) {
+            packaging.jniLibs.pickFirsts.set([])
             packaging.jniLibs.excludes.add('**/**/libjsc*')
             packaging.jniLibs.excludes.add('**/**/libhermes*')
         }
+        onVariants(selector().withBuildType('debug')) {
+            packaging.jniLibs.pickFirsts.set([])
+            packaging.jniLibs.excludes.add('**/**/libjsc*')
+            packaging.jniLibs.pickFirsts.add('**/**/libhermes*')
+        }
     }
-}`;
+}
+`;
 
   let mergeResults: MergeResults;
   mergeResults = mergeContents({


### PR DESCRIPTION
# Why

the current plugin breaks on expo sdk 49 (react-native 0.72) because [RNGP will exclude the **libhermes.so** when hermesEnabled=true](https://github.com/facebook/react-native/blob/62e9faefd5f12f5fe6dc88a076ddf7cafda75ee5/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt#L126-L153)

expo-dev-menu requires the hermes in debug build because it does not support v8

# How

update the variant to keep libhermes.so

# Test Plan

try the reproducible example from https://github.com/expo/expo/issues/23312