### PR TITLE
Check runtimeExecutor before calling onMainLoopIdle

### DIFF
--- a/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Module.java
+++ b/android/src/main/java/io/csie/kudo/reactnative/v8/executor/V8Module.java
@@ -58,7 +58,11 @@ public class V8Module
       final RuntimeExecutor runtimeExecutor = getReactApplicationContext()
                                                   .getCatalystInstance()
                                                   .getRuntimeExecutor();
-      V8Executor.onMainLoopIdle(runtimeExecutor);
+                                                  
+      if (runtimeExecutor != null) {
+        V8Executor.onMainLoopIdle(runtimeExecutor);
+      }
+
       mLastMainLoopIdleCallbackTime = SystemClock.uptimeMillis();
     }
     return true;


### PR DESCRIPTION
Fixes https://github.com/Kudo/react-native-v8/issues/193

I don't understand why `runtimeExecutor` is null here so this is quite a simplistic fix.  If I have some more time I can investigate further, but for the moment this unblocks debugging with RN0.72.