### PR TITLE
Fix build error from react-native 0.74.3

### DIFF
--- a/RNV8.podspec
+++ b/RNV8.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     'HEADER_SEARCH_PATHS' => "\"$(PODS_ROOT)/boost\"",
   }
 
-  compiler_flags = folly_compiler_flags + ' ' + "-DREACT_NATIVE_TARGET_VERSION=#{reactNativeTargetVersion}"
+  compiler_flags = folly_compiler_flags + ' ' + "-DREACT_NATIVE_MINOR_VERSION=#{reactNativeTargetVersion}"
   s.compiler_flags = compiler_flags
 
   s.dependency 'v8-ios'

--- a/RNV8.podspec
+++ b/RNV8.podspec
@@ -11,7 +11,9 @@ end
 if ENV["REACT_NATIVE_OVERRIDE_VERSION"]
   reactNativeVersion = ENV["REACT_NATIVE_OVERRIDE_VERSION"]
 end
-reactNativeTargetVersion = reactNativeVersion.split('.')[1].to_i
+reactNativeVersions = reactNativeVersion.split('.')
+reactNativeMinorVersion = reactNativeVersions[1].to_i
+reactNativePatchVersion = reactNativeVersions[2].to_i
 
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -Wno-comma -Wno-shorten-64-to-32'
 
@@ -33,7 +35,7 @@ Pod::Spec.new do |s|
     'HEADER_SEARCH_PATHS' => "\"$(PODS_ROOT)/boost\"",
   }
 
-  compiler_flags = folly_compiler_flags + ' ' + "-DREACT_NATIVE_MINOR_VERSION=#{reactNativeTargetVersion}"
+  compiler_flags = folly_compiler_flags + ' ' + "-DREACT_NATIVE_MINOR_VERSION=#{reactNativeMinorVersion} -DREACT_NATIVE_PATCH_VERSION=#{reactNativePatchVersion}"
   s.compiler_flags = compiler_flags
 
   s.dependency 'v8-ios'

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
     set (CMAKE_CXX_STANDARD 17)
 endif()
 
-string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION} -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare -fstack-protector-all")
+string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION} -DREACT_NATIVE_PATCH_VERSION=${REACT_NATIVE_PATCH_VERSION} -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare -fstack-protector-all")
 
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -10,13 +10,13 @@ cmake_minimum_required(VERSION 3.13)
 project(react-native-v8)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-if(${REACT_NATIVE_TARGET_VERSION} GREATER_EQUAL 73)
+if(${REACT_NATIVE_MINOR_VERSION} GREATER_EQUAL 73)
     set (CMAKE_CXX_STANDARD 20)
 else()
     set (CMAKE_CXX_STANDARD 17)
 endif()
 
-string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION} -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare -fstack-protector-all")
+string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION} -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare -fstack-protector-all")
 
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,7 +135,7 @@ android {
       cmake {
         arguments "-DANDROID_STL=c++_shared",
                   "-DREACT_NATIVE_DIR=${toPlatformFileString(reactNativeDir)}",
-                  "-DREACT_NATIVE_TARGET_VERSION=${rnMinorVersion}",
+                  "-DREACT_NATIVE_MINOR_VERSION=${rnMinorVersion}",
                   "-DV8_ANDROID_DIR=${v8AndroidDir}",
                   "-DSO_DIR=${extractSoDir}"
         targets   "v8executor"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,7 @@ def reactNativeManifestAsJson = new JsonSlurper().parseText(reactNativeManifest.
 def reactNativeVersion = reactNativeManifestAsJson.version as String
 def (major, minor, patch) = reactNativeVersion.tokenize('.')
 def rnMinorVersion = Integer.parseInt(minor)
+def rnPatchVersion = Integer.parseInt(patch)
 def extractSoDir = "${buildDir}/jniLibs"
 def prefabHeadersDir = "${buildDir}/prefab-headers"
 
@@ -136,6 +137,7 @@ android {
         arguments "-DANDROID_STL=c++_shared",
                   "-DREACT_NATIVE_DIR=${toPlatformFileString(reactNativeDir)}",
                   "-DREACT_NATIVE_MINOR_VERSION=${rnMinorVersion}",
+                  "-DREACT_NATIVE_PATCH_VERSION=${rnPatchVersion}",
                   "-DV8_ANDROID_DIR=${v8AndroidDir}",
                   "-DSO_DIR=${extractSoDir}"
         targets   "v8executor"

--- a/src/v8runtime/V8Inspector.h
+++ b/src/v8runtime/V8Inspector.h
@@ -11,7 +11,7 @@
 #include <condition_variable>
 #include "v8-inspector.h"
 
-#if REACT_NATIVE_TARGET_VERSION >= 73
+#if REACT_NATIVE_MINOR_VERSION >= 73
 
 #if __has_include(<React-jsinspector/jsinspector/InspectorInterfaces.h>)
 #include <React-jsinspector/jsinspector/InspectorInterfaces.h>
@@ -23,7 +23,7 @@ namespace jsinspector = facebook::react::jsinspector_modern;
 #else
 #include "jsinspector/InspectorInterfaces.h"
 namespace jsinspector = facebook::react;
-#endif // REACT_NATIVE_TARGET_VERSION >= 73
+#endif // REACT_NATIVE_MINOR_VERSION >= 73
 
 namespace rnv8 {
 

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -414,6 +414,12 @@ jsi::Value V8Runtime::evaluatePreparedJavaScript(
   return evaluateJavaScript(sourceJs, sourceJs->sourceURL());
 }
 
+#if REACT_NATIVE_MINOR_VERSION >= 75 || (REACT_NATIVE_MINOR_VERSION >= 74 && REACT_NATIVE_PATCH_VERSION >= 3)
+void V8Runtime::queueMicrotask(const jsi::Function &callback) {
+  // TODO: add this when we revisit new architecture support
+}
+#endif // REACT_NATIVE_MINOR_VERSION >= 75 || (REACT_NATIVE_MINOR_VERSION >= 74 && REACT_NATIVE_PATCH_VERSION >= 3
+
 bool V8Runtime::drainMicrotasks(int maxMicrotasksHint) {
   v8::Locker locker(isolate_);
   v8::Isolate::Scope scopedIsolate(isolate_);

--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -467,7 +467,7 @@ jsi::Runtime::PointerValue *V8Runtime::cloneSymbol(
   return new V8PointerValue(isolate_, v8PointerValue->Get(isolate_));
 }
 
-#if REACT_NATIVE_TARGET_VERSION >= 70
+#if REACT_NATIVE_MINOR_VERSION >= 70
 jsi::Runtime::PointerValue *V8Runtime::cloneBigInt(
     const Runtime::PointerValue *pv) {
   if (!pv) {
@@ -572,7 +572,7 @@ jsi::PropNameID V8Runtime::createPropNameIDFromString(const jsi::String &str) {
       reinterpret_cast<const uint8_t *>(*utf8), utf8.length());
 }
 
-#if REACT_NATIVE_TARGET_VERSION >= 69
+#if REACT_NATIVE_MINOR_VERSION >= 69
 jsi::PropNameID V8Runtime::createPropNameIDFromSymbol(
     const facebook::jsi::Symbol &sym) {
   v8::Locker locker(isolate_);
@@ -1076,7 +1076,7 @@ bool V8Runtime::hasProperty(
 }
 
 void V8Runtime::setPropertyValue(
-#if REACT_NATIVE_TARGET_VERSION >= 72
+#if REACT_NATIVE_MINOR_VERSION >= 72
     const jsi::Object &object,
 #else
     jsi::Object &object,
@@ -1102,7 +1102,7 @@ void V8Runtime::setPropertyValue(
 }
 
 void V8Runtime::setPropertyValue(
-#if REACT_NATIVE_TARGET_VERSION >= 72
+#if REACT_NATIVE_MINOR_VERSION >= 72
     const jsi::Object &object,
 #else
     jsi::Object &object,
@@ -1228,7 +1228,7 @@ jsi::WeakObject V8Runtime::createWeakObject(const jsi::Object &weakObject) {
       new V8PointerValue(isolate_, std::move(weakRef)));
 }
 
-#if REACT_NATIVE_TARGET_VERSION >= 72
+#if REACT_NATIVE_MINOR_VERSION >= 72
 jsi::Value V8Runtime::lockWeakObject(const jsi::WeakObject &weakObject) {
 #else
 jsi::Value V8Runtime::lockWeakObject(jsi::WeakObject &weakObject) {
@@ -1314,7 +1314,7 @@ jsi::Value V8Runtime::getValueAtIndex(const jsi::Array &array, size_t i) {
 }
 
 void V8Runtime::setValueAtIndexImpl(
-#if REACT_NATIVE_TARGET_VERSION >= 72
+#if REACT_NATIVE_MINOR_VERSION >= 72
     const jsi::Array &array,
 #else
     jsi::Array &array,
@@ -1479,7 +1479,7 @@ bool V8Runtime::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const {
   return result;
 }
 
-#if REACT_NATIVE_TARGET_VERSION >= 70
+#if REACT_NATIVE_MINOR_VERSION >= 70
 bool V8Runtime::strictEquals(const jsi::BigInt &a, const jsi::BigInt &b) const {
   v8::Locker locker(isolate_);
   v8::Isolate::Scope scopedIsolate(isolate_);
@@ -1552,7 +1552,7 @@ bool V8Runtime::instanceOf(const jsi::Object &o, const jsi::Function &f) {
   return result;
 }
 
-#if REACT_NATIVE_TARGET_VERSION >= 74
+#if REACT_NATIVE_MINOR_VERSION >= 74
 void V8Runtime::setExternalMemoryPressure(const jsi::Object &obj, size_t amount) {
 }
 #endif

--- a/src/v8runtime/V8Runtime.h
+++ b/src/v8runtime/V8Runtime.h
@@ -75,6 +75,9 @@ class V8Runtime : public facebook::jsi::Runtime {
       const std::shared_ptr<const facebook::jsi::PreparedJavaScript> &js)
       override;
 
+#if REACT_NATIVE_MINOR_VERSION >= 75 || (REACT_NATIVE_MINOR_VERSION >= 74 && REACT_NATIVE_PATCH_VERSION >= 3)
+  void queueMicrotask(const facebook::jsi::Function &callback) override;
+#endif // REACT_NATIVE_MINOR_VERSION >= 75 || (REACT_NATIVE_MINOR_VERSION >= 74 && REACT_NATIVE_PATCH_VERSION >= 3
   bool drainMicrotasks(int maxMicrotasksHint = -1) override;
 
   facebook::jsi::Object global() override;

--- a/src/v8runtime/V8Runtime.h
+++ b/src/v8runtime/V8Runtime.h
@@ -83,7 +83,7 @@ class V8Runtime : public facebook::jsi::Runtime {
 
  protected:
   PointerValue *cloneSymbol(const Runtime::PointerValue *pv) override;
-#if REACT_NATIVE_TARGET_VERSION >= 70
+#if REACT_NATIVE_MINOR_VERSION >= 70
   PointerValue *cloneBigInt(const Runtime::PointerValue *pv) override;
 #endif
   PointerValue *cloneString(const Runtime::PointerValue *pv) override;
@@ -98,7 +98,7 @@ class V8Runtime : public facebook::jsi::Runtime {
       size_t length) override;
   facebook::jsi::PropNameID createPropNameIDFromString(
       const facebook::jsi::String &str) override;
-#if REACT_NATIVE_TARGET_VERSION >= 69
+#if REACT_NATIVE_MINOR_VERSION >= 69
   facebook::jsi::PropNameID createPropNameIDFromSymbol(
       const facebook::jsi::Symbol &sym) override;
 #endif
@@ -150,7 +150,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   bool hasProperty(
       const facebook::jsi::Object &,
       const facebook::jsi::String &name) override;
-#if REACT_NATIVE_TARGET_VERSION >= 72
+#if REACT_NATIVE_MINOR_VERSION >= 72
   void setPropertyValue(
       const facebook::jsi::Object &,
       const facebook::jsi::PropNameID &name,
@@ -179,7 +179,7 @@ class V8Runtime : public facebook::jsi::Runtime {
 
   facebook::jsi::WeakObject createWeakObject(
       const facebook::jsi::Object &) override;
-#if REACT_NATIVE_TARGET_VERSION >= 72
+#if REACT_NATIVE_MINOR_VERSION >= 72
   facebook::jsi::Value lockWeakObject(
       const facebook::jsi::WeakObject &) override;
 #else
@@ -194,7 +194,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   uint8_t *data(const facebook::jsi::ArrayBuffer &) override;
   facebook::jsi::Value getValueAtIndex(const facebook::jsi::Array &, size_t i)
       override;
-#if REACT_NATIVE_TARGET_VERSION >= 72
+#if REACT_NATIVE_MINOR_VERSION >= 72
   void setValueAtIndexImpl(
       const facebook::jsi::Array &,
       size_t i,
@@ -223,7 +223,7 @@ class V8Runtime : public facebook::jsi::Runtime {
   bool strictEquals(
       const facebook::jsi::Symbol &a,
       const facebook::jsi::Symbol &b) const override;
-#if REACT_NATIVE_TARGET_VERSION >= 70
+#if REACT_NATIVE_MINOR_VERSION >= 70
   bool strictEquals(
       const facebook::jsi::BigInt &a,
       const facebook::jsi::BigInt &b) const override;
@@ -239,7 +239,7 @@ class V8Runtime : public facebook::jsi::Runtime {
       const facebook::jsi::Object &o,
       const facebook::jsi::Function &f) override;
 
-#if REACT_NATIVE_TARGET_VERSION >= 74
+#if REACT_NATIVE_MINOR_VERSION >= 74
   void setExternalMemoryPressure(
       const facebook::jsi::Object &obj,
       size_t amount) override;


### PR DESCRIPTION
# Why

react-native 0.74.3 has a new `queueMicrotask` interface to jsi and break existing 0.74.3 build

# How

add no-op `queueMicrotask` implementation since it's used from new architecture. i'll add this when revisiting new architecture support.