### PR TITLE
fix: make v8::Exception a string before calling ToSTLString

### DIFF
--- a/src/v8runtime/V8Runtime.cpp
+++ b/src/v8runtime/V8Runtime.cpp
@@ -259,8 +259,11 @@ jsi::Value V8Runtime::ExecuteScript(
 void V8Runtime::ReportException(v8::Isolate *isolate, v8::TryCatch *tryCatch)
     const {
   v8::HandleScope scopedHandle(isolate);
-  std::string exception =
-      JSIV8ValueConverter::ToSTLString(isolate, tryCatch->Exception());
+  std::string exception = JSIV8ValueConverter::ToSTLString(
+      isolate,
+      tryCatch->Exception()
+          ->ToDetailString(isolate->GetCurrentContext())
+          .FromMaybe(v8::Local<v8::String>()));
   v8::Local<v8::Message> message = tryCatch->Message();
   if (message.IsEmpty()) {
     // V8 didn't provide any extra information about this error; just


### PR DESCRIPTION
The value was not a string, changed it to explicitly retrieve the string.

towards fixing: https://github.com/Kudo/react-native-v8/issues/215 (but ReportException still has issues)